### PR TITLE
配置 `ruff` 规则集

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,12 @@ authors = [
 ]
 description = "A powerful and artistic UI library based on PyQt5 / PySide6"
 readme = "README.md"
+license = {file = "LICENSE"}
 requires-python = ">=3.8"
 dependencies = ["PyQt5>=5.15.10"]
 
 [project.urls]
 Repository = "https://github.com/ChinaIceF/PyQt-SiliconUI"
+
+[tool.ruff.lint]
+select = ["I", "E", "W", "F", "C", "Q", "PT", "UP", "PYI", "T20"]


### PR DESCRIPTION
规范化项目 #6 添加 `ruff` 做为默认的 linter 并配置规则集，同时添加了许可证协议