### PR TITLE
配置 `ruff` formatter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,12 +7,16 @@ authors = [
 ]
 description = "A powerful and artistic UI library based on PyQt5 / PySide6"
 readme = "README.md"
-license = {file = "LICENSE"}
+license = { file = "LICENSE" }
 requires-python = ">=3.8"
 dependencies = ["PyQt5>=5.15.10"]
 
 [project.urls]
 Repository = "https://github.com/ChinaIceF/PyQt-SiliconUI"
+
+[tool.ruff]
+line-length = 120
+target-version = "py38"
 
 [tool.ruff.lint]
 select = ["I", "E", "W", "F", "C", "Q", "PT", "UP", "PYI", "T20"]


### PR DESCRIPTION
配置行长度为 120，因为 Qt 的代码长度较长，较短的行长度会产生过多换行，大于 120 就有点离经叛道了。规范 Python 版本为 3.8，ruff 会找出不兼容的语法 #6 