### PR TITLE
添加开发者依赖

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,12 @@ dependencies = ["PyQt5>=5.15.10"]
 [project.urls]
 Repository = "https://github.com/ChinaIceF/PyQt-SiliconUI"
 
+[tool.pdm.dev-dependencies]
+stub = ["pyqt5-stubs>=5.15.6.0"]
+lint = ["ruff>=0.5.0"]
+build = ["nuitka>=2.3.10"]
+profile = ["viztracer>=0.16.3"]
+
 [tool.ruff]
 line-length = 120
 target-version = "py38"


### PR DESCRIPTION
为项目添加开发者依赖，这些依赖不包含在组件库依赖中，而是任何需要开发组件时安装

详情参阅 https://pdm-project.org/en/latest/usage/dependency/#add-development-only-dependencies

> PDM also supports defining groups of dependencies that are useful for development, e.g. some for testing and others for linting. We usually don't want these dependencies appear in the distribution's metadata so using optional-dependencies is probably not a good idea. We can define them as development dependencies

 其中 `pyqt5-stubs` 提供更好地类型存根，`ruff` 是集成的解决方案，从格式化到检查，`nuitka` 用于编译构建不同平台的二进制，`viztracer` 用来进行性能测量和改善可观测性