### PR TITLE
修复了scrollarea的bug

### DIFF
--- a/siui/components/widgets/scrollarea.py
+++ b/siui/components/widgets/scrollarea.py
@@ -149,9 +149,14 @@ class SiScrollArea(SiWidget):
         self.widget_scroll_animation.setTarget(target)
 
         # 计算滚动条的目标位置
-        process = -target[1] / (self.attachment_.height() - self.height())
-        scroll_bar_vertical_target_y = int(process * (self.height() - self.scroll_bar_vertical.height()))
+        attachment_height = self.attachment_.height()
+        if attachment_height == self.height():  # 避免分母为 0
+            process = 0
+        else:
+            process = -target[1] / (attachment_height - self.height())
 
+        scroll_bar_vertical_target_y = int(process * (self.height() - self.scroll_bar_vertical.height()))
+        
         # 如果竖直方向滚动条可见，尝试启动动画
         if self.scroll_bar_vertical.isVisible():
             self.scroll_bar_vertical.moveTo(0, scroll_bar_vertical_target_y)


### PR DESCRIPTION
scrollarea在特定的比例下使用鼠标滚轮可能会出现int(NAN)的情况，例如在1200*700的主界面比例下，打开全局左侧抽屉，然后使用鼠标滚轮就会出现。本提交仅仅是多加了个判断防止情况发生。