### PR TITLE
fix: 将_text_indi_width转换为整数以避免类型错误

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,64 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## 项目概述
+
+PyQt-SiliconUI 是一个基于 PyQt5/PySide6 的强大艺术化 UI 库，提供现代化的 UI 组件和动画效果。
+
+## 开发命令
+
+**安装依赖和库:**
+```bash
+python setup.py install
+```
+
+**运行示例画廊:**
+```bash
+python examples/Gallery\ for\ siui/start.py
+```
+
+**运行 My-TODOs 示例:**
+```bash
+python examples/My-TODOs/start.py
+```
+
+## 项目结构
+
+```
+PyQt-SiliconUI/
+├── siui/                    # 核心 UI 库
+│   ├── components/          # UI 组件
+│   │   ├── button.py       # 按钮组件（已重构）
+│   │   ├── container.py    # 容器组件（已重构）
+│   │   ├── editor.py       # 输入编辑组件（已重构）
+│   │   ├── graphic.py      # 图形相关组件
+│   │   ├── label.py        # 标签和文本组件
+│   │   ├── layout.py       # 布局组件
+│   │   ├── menu_.py        # 菜单组件
+│   │   ├── popover.py      # 弹出层组件
+│   │   ├── progress_bar_.py # 进度条组件
+│   │   └── slider_.py      # 滑块组件
+│   └── core/               # 核心功能
+│       ├── animation.py   # 动画工具
+│       ├── event_filter.py # 事件过滤器
+│       └── painter.py      # 绘图功能
+├── examples/               # 示例代码
+│   ├── Gallery for siui/   # 组件展示画廊
+│   └── My-TODOs/          # To-Do 应用示例
+└── setup.py               # 安装脚本
+```
+
+## 重要说明
+
+1. **重构状态**: 项目正在进行大规模重构，优先使用 `siui/components/` 目录下标记为"已重构"的组件
+2. **依赖**: 需要 PyQt5>=5.15.10, numpy, pyperclip
+3. **开发状态**: Alpha 阶段，尚未发布到 PyPi
+4. **许可证**: GPL-3.0
+
+## 开发建议
+
+- 优先使用重构后的组件（参见 README 中的重构模块列表）
+- 避免使用旧的应用程序模板，等待重构完成
+- 组件开发遵循 Qt 的布局系统
+- 动画使用 `siui/core/animation.py` 中的工具

--- a/siui/components/editbox.py
+++ b/siui/components/editbox.py
@@ -391,7 +391,8 @@ class SiCapsuleLineEdit(QLineEdit):
         container_margins = self._calcContainerMargins()
 
         shrunk_rect = rect.marginsRemoved(container_margins)
-        indi_rect = QRect(shrunk_rect.topLeft() + QPoint(16, 34), QSize(self._text_indi_width + 8, 2))
+        indi_rect = QRect(shrunk_rect.topLeft() + QPoint(16, 34), QSize(int(self._text_indi_width + 8), 2))
+       #indi_rect = QRect(shrunk_rect.topLeft() + QPoint(16, 34), QSize(self._text_indi_width + 8, 2))
 
         path = QPainterPath()
         path.addRoundedRect(QRectF(indi_rect), 1, 1)


### PR DESCRIPTION
fix: 将_text_indi_width转换为整数以避免类型错误：

Traceback (most recent call last):
    File "C:\Users\We3q\AppData\Local\Programs\Python\Python310\lib\site-
  packages\siui\components\editbox.py", line 411, in paintEvent
      self._drawIndicatorRect(painter, text_rect)
    File "C:\Users\We3q\AppData\Local\Programs\Python\Python310\lib\site-
  packages\siui\components\editbox.py", line 394, in _drawIndicatorRect
      indi_rect = QRect(shrunk_rect.topLeft() + QPoint(16, 34),
  QSize(self._text_indi_width + 8, 2))
  TypeError: arguments did not match any overloaded call:
    QSize(): too many arguments
    QSize(w: int, h: int): argument 1 has unexpected type 'float'
    QSize(a0: QSize): argument 1 has unexpected type 'float'

● 这个错误是因为 self._text_indi_width 是一个浮点数，但 QSize
  构造函数需要整数参数。让我修复这个问题。

  错误的具体原因是：siui/components/editbox.py:394 行中
  self._text_indi_width 是一个浮点数，但 QSize
  构造函数只接受整数参数。通过添加 int() 转换解决了这个问题。
  
Q:我是如何触发这个问题的？
A:我在控件页下面的项目名称、项目所属人的文本框内输入中文字符时，出现的错误。修改代码后，重新安装依赖后再次启动项目，再次在输入框内输入中文字符后不再出现这个报错。